### PR TITLE
Add Proteus Job Skeleton

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,749 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+
+	<groupId>eu.proteus</groupId>
+	<artifactId>proteus-job_2.10</artifactId>
+	<name>proteus-job</name>
+	<version>0.1-SNAPSHOT</version>
+
+	<packaging>jar</packaging>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<java.version>1.7</java.version>
+		<scala.macros.version>2.0.1</scala.macros.version>
+		<log4j.configuration>log4j-test.properties</log4j.configuration>
+		<flink.version>1.4-SNAPSHOT</flink.version>
+		<scala.version>${scala.binary.version}.4</scala.version>
+		<scala.binary.version>2.10</scala.binary.version>
+		<metrics.version>3.1.0</metrics.version>
+		<junit.version>4.12</junit.version>
+		<mockito.version>1.10.19</mockito.version>
+		<powermock.version>1.6.5</powermock.version>
+		<slf4j.version>1.7.7</slf4j.version>
+		<log4j.version>1.2.17</log4j.version>
+		<solma.version>0.1-SNAPSHOT</solma.version>
+		<kafka.version>0.10.0.1</kafka.version>
+		<kafka.version.major>0.10</kafka.version.major>
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>apache.snapshots</id>
+			<name>Apache Development Snapshot Repository</name>
+			<url>https://repository.apache.org/content/repositories/snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<distributionManagement>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
+	</distributionManagement>
+
+	<dependencies>
+
+		<!-- core dependencies -->
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<version>1.1.3</version>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.1.3</version>
+		</dependency>
+
+		<!-- Add the log4j -> sfl4j (-> logback) bridge into the classpath
+		 Hadoop is logging to log4j! -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>log4j-over-slf4j</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>eu.proteus</groupId>
+			<artifactId>proteus-solma_${scala.binary.version}</artifactId>
+			<version>${solma.version}</version>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-contrib_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-statebackend-rocksdb_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka-${kafka.version.major}_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+			<version>${scala.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-reflect</artifactId>
+			<version>${scala.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-compiler</artifactId>
+			<version>${scala.version}</version>
+		</dependency>
+
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.scalatest</groupId>
+			<artifactId>scalatest_${scala.binary.version}</artifactId>
+			<version>2.2.2</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka-0.10_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<!-- include 0.10 server for tests  -->
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka_${scala.binary.version}</artifactId>
+			<version>${kafka.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka-base_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-jmx</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!-- root dependencies -->
+
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+		</dependency>
+
+	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+
+			<!-- This manages the 'javax.annotation' annotations (JSR305) -->
+			<dependency>
+				<groupId>com.google.code.findbugs</groupId>
+				<artifactId>jsr305</artifactId>
+				<version>1.3.9</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>3.3.2</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.reflections</groupId>
+				<artifactId>reflections</artifactId>
+				<version>0.9.10</version>
+				<scope>test</scope>
+			</dependency>
+
+		</dependencies>
+
+	</dependencyManagement>
+
+	
+	<profiles>
+
+		<profile>
+			<id>default</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<properties>
+				<suffix.test>(?&lt;!(IT|Integration))(Test|Suite|Case)</suffix.test>
+				<suffix.it>(IT|Integration)(Test|Suite|Case)</suffix.it>
+			</properties>
+		</profile>
+
+		<profile>
+			<!-- Profile for packaging correct JAR files -->
+			<id>build-jar</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-scala_${scala.binary.version}</artifactId>
+					<version>${flink.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
+					<version>${flink.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-clients_${scala.binary.version}</artifactId>
+					<version>${flink.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+					<version>${slf4j.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+					<version>${log4j.version}</version>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
+
+			<properties>
+				<suffix.test>(?&lt;!(IT|Integration))(Test|Suite|Case)</suffix.test>
+				<suffix.it>(IT|Integration)(Test|Suite|Case)</suffix.it>
+			</properties>
+
+			<build>
+				<plugins>
+					<!-- disable the exclusion rules -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>2.4.1</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<artifactSet>
+										<excludes combine.self="override"></excludes>
+									</artifactSet>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
+	<!-- We use the maven-assembly plugin to create a fat jar that contains all dependencies
+		except flink and its transitive dependencies. The resulting fat-jar can be executed
+		on a cluster. Change the value of Program-Class if your program entry point changes. -->
+	<build>
+		<plugins>
+			<!-- We use the maven-shade plugin to create a fat jar that contains all dependencies
+			except flink and it's transitive dependencies. The resulting fat-jar can be executed
+			on a cluster. Change the value of Program-Class if your program entry point changes. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>2.4.1</version>
+				<executions>
+					<!-- Run shade goal on package phase -->
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<excludes>
+									<!-- This list contains all dependencies of flink-dist
+									Everything else will be packaged into the fat-jar
+									-->
+									<exclude>org.apache.flink:flink-annotations</exclude>
+									<exclude>org.apache.flink:flink-shaded-hadoop2</exclude>
+									<exclude>org.apache.flink:flink-shaded-curator-recipes</exclude>
+									<exclude>org.apache.flink:flink-core</exclude>
+									<exclude>org.apache.flink:flink-java</exclude>
+									<exclude>org.apache.flink:flink-scala_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-runtime_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-optimizer_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-clients_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-avro_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-examples-batch_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-examples-streaming_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-streaming-java_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-streaming-scala_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-scala-shell_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-python</exclude>
+									<exclude>org.apache.flink:flink-metrics-core</exclude>
+									<exclude>org.apache.flink:flink-metrics-jmx</exclude>
+									<exclude>org.apache.flink:flink-test-utils_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-tests_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-statebackend-rocksdb_${scala.binary.version}</exclude>
+
+									<!-- Also exclude very big transitive dependencies of Flink
+									WARNING: You have to remove these excludes if your code relies on other
+									versions of these dependencies.
+									-->
+
+									<exclude>log4j:log4j</exclude>
+									<exclude>org.scala-lang:scala-library</exclude>
+									<exclude>org.scala-lang:scala-compiler</exclude>
+									<exclude>org.scala-lang:scala-reflect</exclude>
+									<exclude>com.data-artisans:flakka-actor_*</exclude>
+									<exclude>com.data-artisans:flakka-remote_*</exclude>
+									<exclude>com.data-artisans:flakka-slf4j_*</exclude>
+									<exclude>com.data-artisans:frocksdbjni</exclude>
+									<exclude>io.netty:netty-all</exclude>
+									<exclude>io.netty:netty</exclude>
+									<exclude>commons-fileupload:commons-fileupload</exclude>
+									<exclude>org.apache.avro:avro</exclude>
+									<exclude>commons-collections:commons-collections</exclude>
+									<exclude>com.thoughtworks.paranamer:paranamer</exclude>
+									<exclude>org.xerial.snappy:snappy-java</exclude>
+									<exclude>org.apache.commons:commons-compress</exclude>
+									<exclude>org.tukaani:xz</exclude>
+									<exclude>com.esotericsoftware.kryo:kryo</exclude>
+									<exclude>com.esotericsoftware.minlog:minlog</exclude>
+									<exclude>org.objenesis:objenesis</exclude>
+									<exclude>com.twitter:chill_*</exclude>
+									<exclude>com.twitter:chill-java</exclude>
+									<exclude>commons-lang:commons-lang</exclude>
+									<exclude>junit:junit</exclude>
+									<exclude>org.apache.commons:commons-lang3</exclude>
+									<exclude>org.slf4j:slf4j-api</exclude>
+									<exclude>org.slf4j:slf4j-log4j12</exclude>
+									<exclude>log4j:log4j</exclude>
+									<exclude>org.apache.commons:commons-math</exclude>
+									<exclude>org.apache.sling:org.apache.sling.commons.json</exclude>
+									<exclude>commons-logging:commons-logging</exclude>
+									<exclude>commons-codec:commons-codec</exclude>
+									<exclude>com.fasterxml.jackson.core:jackson-core</exclude>
+									<exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
+									<exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
+									<exclude>stax:stax-api</exclude>
+									<exclude>com.typesafe:config</exclude>
+									<exclude>org.uncommons.maths:uncommons-maths</exclude>
+									<exclude>com.github.scopt:scopt_*</exclude>
+									<exclude>commons-io:commons-io</exclude>
+									<exclude>commons-cli:commons-cli</exclude>
+								</excludes>
+							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>org.apache.flink:*</artifact>
+									<excludes>
+										<!-- exclude shaded google but include shaded curator -->
+										<exclude>org/apache/flink/shaded/com/**</exclude>
+										<exclude>web-docs/**</exclude>
+									</excludes>
+								</filter>
+								<filter>
+									<!-- Do not copy the signatures in the META-INF folder.
+									Otherwise, this might cause SecurityExceptions when using the JAR. -->
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<!-- If you want to use ./bin/flink run <quickstart jar> uncomment the following lines.
+							This will add a Main-Class entry to the manifest file -->
+
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>eu.proteus.job.kernel.ProteusJob</mainClass>
+								</transformer>
+							</transformers>
+
+							<createDependencyReducedPom>false</createDependencyReducedPom>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.9</version>
+				<executions>
+					<execution>
+						<id>unpack</id>
+						<!-- executed just before the package phase -->
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>unpack</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<!-- For Flink connector classes -->
+								<artifactItem>
+									<groupId>org.apache.flink</groupId>
+									<artifactId>flink-connector-kafka</artifactId>
+									<version>${kafka.version.major}-SNAPSHOT</version>
+									<type>jar</type>
+									<overWrite>false</overWrite>
+									<outputDirectory>${project.build.directory}/classes</outputDirectory>
+									<includes>org/apache/flink/**</includes>
+								</artifactItem>
+								<!-- For Kafka API classes -->
+								<artifactItem>
+									<groupId>org.apache.kafka</groupId>
+									<artifactId>kafka_${scala.binary.version}</artifactId>
+									<version>${kafka.version}</version>
+									<type>jar</type>
+									<overWrite>false</overWrite>
+									<outputDirectory>${project.build.directory}/classes</outputDirectory>
+									<includes>kafka/**</includes>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<version>3.2.2</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>compile</goal>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Eclipse Integration -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-eclipse-plugin</artifactId>
+				<version>2.8</version>
+				<configuration>
+					<downloadSources>true</downloadSources>
+					<projectnatures>
+						<projectnature>org.scala-ide.sdt.core.scalanature</projectnature>
+						<projectnature>org.eclipse.jdt.core.javanature</projectnature>
+					</projectnatures>
+					<buildcommands>
+						<buildcommand>org.scala-ide.sdt.core.scalabuilder</buildcommand>
+					</buildcommands>
+					<classpathContainers>
+						<classpathContainer>org.scala-ide.sdt.launching.SCALA_CONTAINER
+						</classpathContainer>
+						<classpathContainer>org.eclipse.jdt.launching.JRE_CONTAINER
+						</classpathContainer>
+					</classpathContainers>
+					<excludes>
+						<exclude>org.scala-lang:scala-library</exclude>
+						<exclude>org.scala-lang:scala-compiler</exclude>
+					</excludes>
+					<sourceIncludes>
+						<sourceInclude>**/*.scala</sourceInclude>
+						<sourceInclude>**/*.java</sourceInclude>
+					</sourceIncludes>
+				</configuration>
+			</plugin>
+
+			<!-- Adding scala source directories to build path -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.7</version>
+				<executions>
+					<!-- Add src/main/scala to eclipse build path -->
+					<execution>
+						<id>add-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/main/scala</source>
+							</sources>
+						</configuration>
+					</execution>
+					<!-- Add src/test/scala to eclipse build path -->
+					<execution>
+						<id>add-test-source</id>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/test/scala</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.scalatest</groupId>
+				<artifactId>scalatest-maven-plugin</artifactId>
+				<version>1.0</version>
+				<configuration>
+					<reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+					<stdout>W</stdout> <!-- Skip coloring output -->
+				</configuration>
+				<executions>
+					<execution>
+						<id>scala-test</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<suffixes>${suffix.test}</suffixes>
+							<argLine>-Xms256m -Xmx1000m -Dlog4j.configuration=${log4j.configuration} -Dmvn.forkNumber=1 -XX:-UseGCOverheadLimit</argLine>
+						</configuration>
+					</execution>
+					<execution>
+						<id>integration-test</id>
+						<phase>integration-test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<suffixes>${suffix.it}</suffixes>
+							<argLine>-Xms256m -Xmx1000m -Dlog4j.configuration=${log4j.configuration} -Dmvn.forkNumber=1 -XX:-UseGCOverheadLimit</argLine>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+		</plugins>
+	</build>
+
+
+</project>

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,24 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+

--- a/src/main/scala/eu/proteus/job/kernel/ProteusJob.scala
+++ b/src/main/scala/eu/proteus/job/kernel/ProteusJob.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.job.kernel
+
+import java.util.Properties
+
+import eu.proteus.job.operations.data.model.{CoilMeasurement, SensorMeasurement1D, SensorMeasurement2D}
+import eu.proteus.job.operations.serializer.CoilMeasurementKryoSerializer
+import grizzled.slf4j.Logger
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.utils.ParameterTool
+import org.apache.flink.contrib.streaming.state.{PredefinedOptions, RocksDBStateBackend}
+import org.apache.flink.streaming.api.TimeCharacteristic
+import org.apache.flink.streaming.api.scala._
+import org.apache.flink.streaming.connectors.kafka.{FlinkKafkaConsumer010, FlinkKafkaProducer010}
+import org.apache.flink.streaming.util.serialization.TypeInformationSerializationSchema
+
+
+object ProteusJob {
+
+  private [kernel] val LOG = Logger(getClass)
+
+  // kafka config
+  private [kernel] var kafkaBootstrapServer = "localhost:2181"
+  private [kernel] var realtimeDataKafkaTopic = "proteus-realtime"
+
+  // flink config
+  private [kernel] var flinkCheckpointsDir = ""
+
+  def loadKafkaProperties = {
+    val properties = new Properties
+    properties.setProperty("bootstrap.servers", kafkaBootstrapServer)
+    properties
+  }
+
+  def configureFlinkEnvironment(env: StreamExecutionEnvironment) = {
+     // configure flink environement
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+
+    val stateBackend = new RocksDBStateBackend(flinkCheckpointsDir, false)
+    stateBackend.setPredefinedOptions(PredefinedOptions.DEFAULT)
+    env.setStateBackend(stateBackend)
+    // checkpoint every 20 mins, exactly once guarantee
+    //env.enableCheckpointing(20 * 60 * 1000, CheckpointingMode.EXACTLY_ONCE)
+
+    env.getConfig.registerTypeWithKryoSerializer(classOf[CoilMeasurement], classOf[CoilMeasurementKryoSerializer])
+    env.getConfig.registerTypeWithKryoSerializer(classOf[SensorMeasurement2D], classOf[CoilMeasurementKryoSerializer])
+    env.getConfig.registerTypeWithKryoSerializer(classOf[SensorMeasurement1D], classOf[CoilMeasurementKryoSerializer])
+  }
+
+  def startProteusJob(parameters: ParameterTool) = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+
+    // configure kafka
+    val kafkaProperties = loadKafkaProperties
+
+    configureFlinkEnvironment(env)
+
+    // create the job
+
+    // type info & serializer
+    val typeInfo = TypeInformation.of(classOf[CoilMeasurement])
+    val schema = new TypeInformationSerializationSchema[CoilMeasurement](typeInfo, env.getConfig)
+
+    // add kafka source
+
+    val source: DataStream[CoilMeasurement] = env.addSource(new FlinkKafkaConsumer010[CoilMeasurement](
+        realtimeDataKafkaTopic,
+        schema,
+        kafkaProperties))
+
+    // add here your analytics
+    // add Kafka sink 1st analytic algo
+    val producerCfg = FlinkKafkaProducer010.writeToKafkaWithTimestamps(
+        source.javaStream,
+        "topic",
+        schema,
+        kafkaProperties)
+
+    producerCfg.setLogFailuresOnly(false)
+    producerCfg.setFlushOnCheckpoint(true)
+
+    // execute the job
+    env.execute("The Proteus Job")
+  }
+
+  def printUsage = {
+    System.out.println("The Flink Kafka Job")
+    System.out.println("Parameters:")
+    System.out.println("--boostrap-server\tKafka Bootstrap Server")
+    System.out.println("--flink-checkpoints-dir\tAn HDFS dir which that " +
+      "store rocksdb checkpoints, e.g., namenode:9000/flink-checkpoints/")
+
+  }
+
+  def main(args: Array[String]) = {
+
+    var parameters: ParameterTool = null
+    try {
+      parameters = ParameterTool.fromArgs(args)
+      kafkaBootstrapServer = parameters.getRequired("bootstrap-server")
+      flinkCheckpointsDir = "hdfs://" + parameters.getRequired("flink-checkpoints-dir")
+    } catch {
+      case t: Throwable =>
+        LOG.error("Error parsing the command line!")
+        printUsage
+        System.exit(-1)
+    }
+
+    try {
+      startProteusJob(parameters)
+    } catch {
+      case t: Throwable =>
+        LOG.error("Failed to run the Proteus Flink Job!")
+        LOG.error(t.getMessage, t)
+    }
+
+  }
+
+}

--- a/src/main/scala/eu/proteus/job/operations/data/model/SensorMeasurement.scala
+++ b/src/main/scala/eu/proteus/job/operations/data/model/SensorMeasurement.scala
@@ -1,0 +1,23 @@
+package eu.proteus.job.operations.data.model
+
+import eu.proteus.solma.events.StreamEvent
+import org.apache.flink.ml.math.Vector
+
+trait CoilMeasurement extends StreamEvent {
+  def coilId: Int
+}
+
+case class SensorMeasurement1D(
+    coilId: Int,
+    x: Double,
+    slice: IndexedSeq[Int],
+    data: Vector
+  ) extends CoilMeasurement
+
+case class SensorMeasurement2D(
+    coilId: Int,
+    x: Double,
+    y: Double,
+    slice: IndexedSeq[Int],
+    data: Vector
+  ) extends CoilMeasurement

--- a/src/main/scala/eu/proteus/job/operations/serializer/CoilMeasurementKryoSerializer.scala
+++ b/src/main/scala/eu/proteus/job/operations/serializer/CoilMeasurementKryoSerializer.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.job.operations.serializer
+
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+import eu.proteus.job.operations.data.model.{CoilMeasurement, SensorMeasurement1D, SensorMeasurement2D}
+import org.apache.flink.ml.math.{DenseVector => FlinkDenseVector}
+
+
+class CoilMeasurementKryoSerializer extends Serializer[CoilMeasurement] {
+
+  private val MAGIC_NUMBER = 0x00687691 // PROTEUS EU id
+
+  override def read(kryo: Kryo, input: Input, t: Class[CoilMeasurement]): CoilMeasurement = {
+
+    val magicNumber = input.readInt()
+    assert(magicNumber == MAGIC_NUMBER)
+    val is2D = (input.readByte() & 0x01) == 1
+    val coilId = input.readInt()
+
+    val x = input.readDouble()
+    val y = if (is2D) {
+      input.readDouble()
+    } else {
+      0.0
+    }
+
+    val variableId = input.readInt()
+    val value = input.readDouble()
+
+    if (is2D) {
+      SensorMeasurement2D(coilId, x, y, variableId to variableId, FlinkDenseVector(value))
+    } else {
+      SensorMeasurement1D(coilId, x, variableId to variableId, FlinkDenseVector(value))
+    }
+  }
+
+  override def write(kryo: Kryo, output: Output, obj: CoilMeasurement): Unit = {
+
+    output.writeInt(MAGIC_NUMBER)
+    val sm = obj match {
+      case s1d: SensorMeasurement1D =>
+        output.writeByte(0x00)
+        output.writeInt(obj.coilId)
+        output.writeDouble(s1d.x)
+        s1d
+      case s2d: SensorMeasurement2D =>
+        output.writeByte(0x01)
+        output.writeInt(obj.coilId)
+        output.writeDouble(s2d.x)
+        output.writeDouble(s2d.y)
+        s2d
+    }
+    output.writeInt(sm.slice.head)
+    output.writeDouble(sm.data(0))
+  }
+}

--- a/src/test/scala/eu/proteus/job/kernel/KafkaIntegrationITSuite.scala
+++ b/src/test/scala/eu/proteus/job/kernel/KafkaIntegrationITSuite.scala
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.job.kernel
+
+import java.lang.reflect.Field
+import java.util.{Properties, UUID}
+
+import eu.proteus.job.operations.data.model.{CoilMeasurement, SensorMeasurement1D, SensorMeasurement2D}
+import eu.proteus.job.operations.serializer.CoilMeasurementKryoSerializer
+import kafka.common.NotLeaderForPartitionException
+import org.apache.flink.api.common.restartstrategy.RestartStrategies
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.client.program.ProgramInvocationException
+import org.apache.flink.ml.math.{DenseVector => FlinkDenseVector}
+import org.apache.flink.runtime.client.JobExecutionException
+import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster
+import org.apache.flink.streaming.api.functions.sink.SinkFunction
+import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
+import org.apache.flink.streaming.api.scala._
+import org.apache.flink.streaming.connectors.kafka.{FlinkKafkaProducerBase, KafkaTestBase, KafkaTestEnvironment}
+import org.apache.flink.streaming.connectors.kafka.testutils.JobManagerCommunicationUtils
+import org.apache.flink.streaming.util.serialization.{KeyedSerializationSchemaWrapper, TypeInformationSerializationSchema}
+import org.apache.flink.test.util.SuccessException
+import org.apache.flink.testutils.junit.RetryOnException
+import org.junit.{After, BeforeClass, Test}
+import org.scalatest.junit.JUnitSuiteLike
+
+import scala.concurrent.duration.FiniteDuration
+
+@Test(timeout = 60000)
+@RetryOnException (times = 2, exception = classOf[NotLeaderForPartitionException] )
+class KafkaIntegrationITSuite
+  extends KafkaTestBase
+  with JUnitSuiteLike {
+
+  import KafkaIntegrationITSuite._
+
+  @Test
+  def runSimpleIntegrationTest(): Unit = {
+
+    val topic = "kafkaProducerConsumerTopic_" + UUID.randomUUID.toString
+
+    val parallelism = 1
+    val elementsPerPartition = 100
+    val totalElements = parallelism * elementsPerPartition
+
+    JobManagerCommunicationUtils.waitUntilNoJobIsRunning(flink.getLeaderGateway(timeout))
+
+    kafkaServer.createTestTopic(topic, parallelism, 1)
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(parallelism)
+    env.enableCheckpointing(500)
+    env.setRestartStrategy(RestartStrategies.noRestart) // fail immediately
+
+    env.getConfig.disableSysoutLogging
+
+    env.getConfig.registerTypeWithKryoSerializer(classOf[CoilMeasurement], classOf[CoilMeasurementKryoSerializer])
+    env.getConfig.registerTypeWithKryoSerializer(classOf[SensorMeasurement2D], classOf[CoilMeasurementKryoSerializer])
+    env.getConfig.registerTypeWithKryoSerializer(classOf[SensorMeasurement1D], classOf[CoilMeasurementKryoSerializer])
+
+    val typeInfo = TypeInformation.of(classOf[CoilMeasurement])
+    val schema = new TypeInformationSerializationSchema[CoilMeasurement](typeInfo, env.getConfig)
+
+    // ----------- add producer dataflow ----------
+
+    val s1 = SensorMeasurement1D(0, 12.0, 0 to 0, FlinkDenseVector(1.0))
+    val s2 = SensorMeasurement2D(0, 12.0, 1.0, 0 to 0, FlinkDenseVector(1.0))
+    val stream = env.addSource((ctx: SourceContext[CoilMeasurement]) => {
+      ctx.collect(s1)
+      ctx.collect(s2)
+    })
+
+    val producerProperties = FlinkKafkaProducerBase.getPropertiesFromBrokerList(brokerConnectionStrings)
+    producerProperties.setProperty("retries", "3")
+    producerProperties.putAll(secureProps)
+
+    kafkaServer.produceIntoKafka(
+      stream.javaStream,
+      topic,
+      new KeyedSerializationSchemaWrapper[CoilMeasurement](schema),
+      producerProperties,
+      null)
+
+    // ----------- add consumer dataflow ----------
+
+    val props = new Properties
+    props.putAll(standardProps)
+    props.putAll(secureProps)
+
+    val source = kafkaServer.getConsumer(topic, schema, props)
+    val consuming = env.addSource(source).setParallelism(parallelism)
+
+    consuming.addSink(new SinkFunction[CoilMeasurement]() {
+      var e = 0
+      override def invoke(in: CoilMeasurement): Unit = {
+        in match {
+          case s1d: SensorMeasurement1D =>
+            e += 1
+            Predef.assert(s1d == s1)
+          case s2d: SensorMeasurement2D =>
+            e += 1
+            Predef.assert(s2d == s2)
+        }
+        if (e == 2) {
+          throw new SuccessException
+        }
+      }
+    }).setParallelism(1)
+
+    try
+      KafkaTestBase.tryExecutePropagateExceptions(env.getJavaEnv, "runSimpleIntegrationTest")
+    catch {
+      case e@(_: ProgramInvocationException | _: JobExecutionException) =>
+        // look for NotLeaderForPartitionException
+        var cause = e.getCause
+        // search for nested SuccessExceptions
+        var depth = 0
+        while ( {
+          cause != null && {
+            depth += 1;
+            depth - 1
+          } < 20
+        }) {
+          if (cause.isInstanceOf[NotLeaderForPartitionException])
+            throw cause.asInstanceOf[Exception]
+          cause = cause.getCause
+        }
+        throw e
+    }
+
+    KafkaTestBase.deleteTestTopic(topic)
+
+  }
+
+  @After
+  def shutdown = KafkaTestBase.shutDownServices()
+
+
+}
+
+object KafkaIntegrationITSuite {
+
+  @BeforeClass
+  def prepare = KafkaTestBase.prepare()
+
+  private def extractField(field: String): Field = {
+    val f = classOf[KafkaTestBase].getDeclaredField(field)
+    f.setAccessible(true)
+    f
+  }
+
+  private val __timeout = extractField("timeout")
+
+  def timeout = __timeout.get(null).asInstanceOf[FiniteDuration]
+
+  private val __flink = extractField("flink")
+
+  def flink = __flink.get(null).asInstanceOf[LocalFlinkMiniCluster]
+
+  private val __kafka = extractField("kafkaServer")
+
+  def kafkaServer = __kafka.get(null).asInstanceOf[KafkaTestEnvironment]
+
+  private val __brokerConnectionStrings = extractField("brokerConnectionStrings")
+
+  def brokerConnectionStrings = __brokerConnectionStrings.get(null).asInstanceOf[String]
+
+  private val __secureProps = extractField("secureProps")
+
+  def secureProps = __secureProps.get(null).asInstanceOf[Properties]
+
+  private val __standardProps = extractField("standardProps")
+
+  def standardProps = __standardProps.get(null).asInstanceOf[Properties]
+
+}

--- a/src/test/scala/eu/proteus/job/kernel/KafkaIntegrationITSuite.scala
+++ b/src/test/scala/eu/proteus/job/kernel/KafkaIntegrationITSuite.scala
@@ -36,7 +36,7 @@ import org.apache.flink.streaming.connectors.kafka.testutils.JobManagerCommunica
 import org.apache.flink.streaming.util.serialization.{KeyedSerializationSchemaWrapper, TypeInformationSerializationSchema}
 import org.apache.flink.test.util.SuccessException
 import org.apache.flink.testutils.junit.RetryOnException
-import org.junit.{After, BeforeClass, Test}
+import org.junit.{AfterClass, BeforeClass, Test}
 import org.scalatest.junit.JUnitSuiteLike
 
 import scala.concurrent.duration.FiniteDuration
@@ -147,9 +147,6 @@ class KafkaIntegrationITSuite
 
   }
 
-  @After
-  def shutdown = KafkaTestBase.shutDownServices()
-
 
 }
 
@@ -157,6 +154,9 @@ object KafkaIntegrationITSuite {
 
   @BeforeClass
   def prepare = KafkaTestBase.prepare()
+
+  @AfterClass
+  def shutdown = KafkaTestBase.shutDownServices()
 
   private def extractField(field: String): Field = {
     val f = classOf[KafkaTestBase].getDeclaredField(field)

--- a/src/test/scala/eu/proteus/job/operations/data/model/CoilMeasurementKryoSerializerUTSuite.scala
+++ b/src/test/scala/eu/proteus/job/operations/data/model/CoilMeasurementKryoSerializerUTSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.job.operations.data.model
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.{Input, Output}
+import eu.proteus.job.operations.serializer.CoilMeasurementKryoSerializer
+import org.apache.flink.ml.math.{DenseVector => FlinkDenseVector}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+@RunWith(classOf[JUnitRunner])
+class CoilMeasurementKryoSerializerUTSuite
+  extends WordSpecLike
+  with Matchers
+  with BeforeAndAfterAll {
+
+  "test kryo serialization" in {
+
+    val kryo = new Kryo()
+    val ser = new CoilMeasurementKryoSerializer
+    kryo.register(classOf[CoilMeasurement], ser)
+    kryo.register(classOf[SensorMeasurement1D], ser)
+    kryo.register(classOf[SensorMeasurement2D], ser)
+
+    val measurement1D = SensorMeasurement1D(0, 12.0, 0 to 0, FlinkDenseVector(1.0))
+    val measurement2D = SensorMeasurement2D(0, 12.0, 1.0, 0 to 0, FlinkDenseVector(1.0))
+
+    val out = new Output(1024)
+    val in = new Input(out.getBuffer)
+
+    kryo.writeObject(out, measurement1D)
+    kryo.writeObject(out, measurement2D)
+
+    val s1 = kryo.readObject(in, classOf[CoilMeasurement])
+    val s2 = kryo.readObject(in, classOf[CoilMeasurement])
+
+    s1 shouldEqual measurement1D
+    s2 shouldEqual measurement2D
+
+  }
+
+}


### PR DESCRIPTION
This PR adds the basic skeleton for the Proteus Job. It contains the coil data model, its kryo serializer and the Flink job configuration. Moreover, I added a IT suite to test the job integration with kafka.