### PR TITLE
Change simple moments output format to include x[,y] coil coords

### DIFF
--- a/src/main/scala/eu/proteus/job/kernel/ProteusJob.scala
+++ b/src/main/scala/eu/proteus/job/kernel/ProteusJob.scala
@@ -29,7 +29,7 @@ import org.apache.flink.contrib.streaming.state.{PredefinedOptions, RocksDBState
 import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala._
 import org.apache.flink.streaming.connectors.kafka.{FlinkKafkaConsumer010, FlinkKafkaProducer010}
-import org.apache.flink.streaming.util.serialization.TypeInformationSerializationSchema
+import org.apache.flink.streaming.util.serialization.{SimpleStringSchema, TypeInformationSerializationSchema}
 
 
 object ProteusJob {
@@ -91,7 +91,9 @@ object ProteusJob {
 
     val moments = MomentsOperation.runSimpleMomentsAnalytics(source, 53)
     val momentsTypeInfo = TypeInformation.of(classOf[MomentsResult])
-    val momentsSinkSchema = new TypeInformationSerializationSchema[MomentsResult](momentsTypeInfo, env.getConfig)
+//  val momentsSinkSchema = new TypeInformationSerializationSchema[MomentsResult](momentsTypeInfo, env.getConfig)
+
+    val momentsSinkSchema = new SimpleStringSchema()
 
     val producerCfg = FlinkKafkaProducer010.writeToKafkaWithTimestamps(
         moments.javaStream,

--- a/src/main/scala/eu/proteus/job/operations/data/results/MomentsResult.scala
+++ b/src/main/scala/eu/proteus/job/operations/data/results/MomentsResult.scala
@@ -19,13 +19,13 @@ package eu.proteus.job.operations.data.results
 import net.liftweb.json.DefaultFormats
 import net.liftweb.json.Serialization.write
 
-case class MomentsResult(
-    coilId: Int,
-    varId: Int,
-    mean: Double,
-    variance: Double,
-    counter: Double
-  ) extends Serializable {
+trait MomentsResult extends Serializable {
+
+  def coilId: Int
+  def varId: Int
+  def mean: Double
+  def variance: Double
+  def counter: Double
 
   def toJson: String = {
     implicit val formats = DefaultFormats
@@ -33,3 +33,23 @@ case class MomentsResult(
   }
 
 }
+
+case class MomentsResult1D(
+  coilId: Int,
+  varId: Int,
+  x: Double,
+  mean: Double,
+  variance: Double,
+  counter: Double) extends MomentsResult
+
+
+case class MomentsResult2D(
+  coilId: Int,
+  varId: Int,
+  x: Double,
+  y: Double,
+  mean: Double,
+  variance: Double,
+  counter: Double) extends MomentsResult
+
+

--- a/src/main/scala/eu/proteus/job/operations/moments/MomentsOperation.scala
+++ b/src/main/scala/eu/proteus/job/operations/moments/MomentsOperation.scala
@@ -33,7 +33,7 @@ object MomentsOperation {
   def runSimpleMomentsAnalytics(
       stream: DataStream[CoilMeasurement],
       featuresCount: Int
-  ): DataStream[MomentsResult] = {
+  ): DataStream[String] = {
 
     implicit val typeInfo = TypeInformation.of(classOf[(CoilMeasurement, Int)])
 
@@ -118,7 +118,7 @@ object MomentsOperation {
             val momentsQueue = earlyMoments.get(pid)
             if (momentsQueue.nonEmpty) {
               val m = momentsQueue.dequeue
-              if (!java.lang.Double.isNaN(m.variance(0))) {
+              if (!m.variance(0).isNaN) {
                 joinAndOutput(m, cid, sid, coords._1, coords._2, out)
               }
             }
@@ -151,7 +151,7 @@ object MomentsOperation {
             momentsQueue += metrics
           } else {
             val (ox, oy) = coordsQueue.dequeue
-            if (!java.lang.Double.isNaN(metrics.variance(0))) {
+            if (!metrics.variance(0).isNaN) {
               joinAndOutput(metrics, cid, sid, ox, oy, out)
             }
           }
@@ -159,9 +159,8 @@ object MomentsOperation {
         }
 
     })
-    .name("coil-xy-join")
     .uid("coil-xy-join")
-
+    .map(x => x.toJson)
 
   }
 

--- a/src/main/scala/eu/proteus/job/operations/moments/MomentsOperation.scala
+++ b/src/main/scala/eu/proteus/job/operations/moments/MomentsOperation.scala
@@ -16,8 +16,6 @@
 
 package eu.proteus.job.operations.moments
 
-import java.beans.Transient
-
 import eu.proteus.job.operations.data.model.{CoilMeasurement, SensorMeasurement1D, SensorMeasurement2D}
 import eu.proteus.job.operations.data.results.{MomentsResult, MomentsResult1D, MomentsResult2D}
 import eu.proteus.solma.moments.MomentsEstimator
@@ -64,7 +62,7 @@ object MomentsOperation {
               case s2d: SensorMeasurement2D => s2d.copy(slice = 0 to 0)
             }
             (clone.asInstanceOf[CoilMeasurement], pid)
-            }
+          }
         )
         .keyBy(x => x._2)
         .asInstanceOf[KeyedStream[(Any, Int), Int]]
@@ -76,49 +74,88 @@ object MomentsOperation {
       .connect(moments.keyBy(x => x._1))
       .flatMap(new RichCoFlatMapFunction[(CoilMeasurement, Int), (Int, MomentsEstimator.Moments), MomentsResult]() {
 
-        @Transient
-        private var map: MapState[Int, mutable.Queue[(Option[Double], Option[Double])]] = _
+        @transient
+        private var coordsMap: MapState[Int, mutable.Queue[(Option[Double], Option[Double])]] = _
+
+        @transient
+        private var earlyMoments: MapState[Int, mutable.Queue[MomentsEstimator.Moments]] = _
 
         override def open(parameters: Configuration): Unit = {
           super.open(parameters)
-          val descriptor = new MapStateDescriptor[Int, mutable.Queue[(Option[Double], Option[Double])]](
+          val coordsDescriptor = new MapStateDescriptor[Int, mutable.Queue[(Option[Double], Option[Double])]](
             "coords",
             TypeInformation.of(classOf[Int]),
             TypeInformation.of(classOf[mutable.Queue[(Option[Double], Option[Double])]])
           )
-          map = getRuntimeContext.getMapState(descriptor)
+          val momentsDescriptor = new MapStateDescriptor[Int, mutable.Queue[MomentsEstimator.Moments]](
+            "moments",
+            TypeInformation.of(classOf[Int]),
+            TypeInformation.of(classOf[mutable.Queue[MomentsEstimator.Moments]])
+          )
+          coordsMap = getRuntimeContext.getMapState(coordsDescriptor)
+          earlyMoments = getRuntimeContext.getMapState(momentsDescriptor)
+        }
+
+        private def joinAndOutput(metrics: MomentsEstimator.Moments, cid: Int, sid: Int,
+            ox: Option[Double], oy: Option[Double], out: Collector[MomentsResult]
+        ): Unit = {
+          val result = oy match {
+            case Some(y) => MomentsResult2D(cid, sid, metrics.mean(0), ox.get, y, metrics.variance(0), metrics.counter(0))
+            case None => MomentsResult1D(cid, sid, metrics.mean(0), ox.get, metrics.variance(0), metrics.counter(0))
+          }
+          out.collect(result)
         }
 
         override def flatMap1(value: (CoilMeasurement, Int), out: Collector[MomentsResult]): Unit = {
-          val key = value._1.coilId * featuresCount + value._1.slice.head
-          val v = value._1 match {
+          val cid = value._1.coilId
+          val sid = value._1.slice.head
+          val pid = cid * featuresCount + sid
+          val coords = value._1 match {
             case s1d: SensorMeasurement1D => (Some(s1d.x), None)
             case s2d: SensorMeasurement2D => (Some(s2d.x), Some(s2d.y))
           }
-          val queue = if (map.contains(key)) {
-            map.get(key)
+          if (earlyMoments.contains(pid)) {
+            val momentsQueue = earlyMoments.get(pid)
+            if (momentsQueue.nonEmpty) {
+              val m = momentsQueue.dequeue
+              if (!java.lang.Double.isNaN(m.variance(0))) {
+                joinAndOutput(m, cid, sid, coords._1, coords._2, out)
+              }
+            }
           } else {
-            val q = mutable.Queue[(Option[Double], Option[Double])]()
-            map.put(key, q)
-            q
+            val coordsQueue = if (coordsMap.contains(pid)) {
+              coordsMap.get(pid)
+            } else {
+              val q = mutable.Queue[(Option[Double], Option[Double])]()
+              coordsMap.put(pid, q)
+              q
+            }
+            coordsQueue += coords
           }
-          queue += v
+
         }
 
         override def flatMap2(in: (Int, MomentsEstimator.Moments), out: Collector[MomentsResult]): Unit = {
           val (pid: Int, metrics: MomentsEstimator.Moments) = in
           val cid = pid % featuresCount
           val sid = pid / featuresCount
-          val q = map.get(pid)
-          if (q.isEmpty) {
-            throw new RuntimeException("this queue is not supposed to be empty!")
+          val coordsQueue = coordsMap.get(pid)
+          if (coordsQueue.isEmpty) {
+            val momentsQueue = if (earlyMoments.contains(pid)) {
+              earlyMoments.get(pid)
+            } else {
+              val q = mutable.Queue[MomentsEstimator.Moments]()
+              earlyMoments.put(pid, q)
+              q
+            }
+            momentsQueue += metrics
+          } else {
+            val (ox, oy) = coordsQueue.dequeue
+            if (!java.lang.Double.isNaN(metrics.variance(0))) {
+              joinAndOutput(metrics, cid, sid, ox, oy, out)
+            }
           }
-          val (ox, oy) = q.dequeue
-          val result = oy match {
-            case Some(y) => MomentsResult2D(cid, sid, metrics.mean(0), ox.get, y, metrics.variance(0), metrics.counter(0))
-            case None => MomentsResult1D(cid, sid, metrics.mean(0), ox.get, metrics.variance(0), metrics.counter(0))
-          }
-          out.collect(result)
+
         }
 
     })

--- a/src/main/scala/eu/proteus/job/operations/moments/MomentsOperation.scala
+++ b/src/main/scala/eu/proteus/job/operations/moments/MomentsOperation.scala
@@ -100,8 +100,8 @@ object MomentsOperation {
             ox: Option[Double], oy: Option[Double], out: Collector[MomentsResult]
         ): Unit = {
           val result = oy match {
-            case Some(y) => MomentsResult2D(cid, sid, metrics.mean(0), ox.get, y, metrics.variance(0), metrics.counter(0))
-            case None => MomentsResult1D(cid, sid, metrics.mean(0), ox.get, metrics.variance(0), metrics.counter(0))
+            case Some(y) => MomentsResult2D(cid, sid, ox.get, y, metrics.mean(0), metrics.variance(0), metrics.counter(0))
+            case None => MomentsResult1D(cid, sid, ox.get, metrics.mean(0), metrics.variance(0), metrics.counter(0))
           }
           out.collect(result)
         }

--- a/src/main/scala/eu/proteus/job/operations/moments/MomentsOperation.scala
+++ b/src/main/scala/eu/proteus/job/operations/moments/MomentsOperation.scala
@@ -16,49 +16,115 @@
 
 package eu.proteus.job.operations.moments
 
-import eu.proteus.job.operations.data.model.CoilMeasurement
-import eu.proteus.job.operations.data.results.MomentsResult
+import java.beans.Transient
+
+import eu.proteus.job.operations.data.model.{CoilMeasurement, SensorMeasurement1D, SensorMeasurement2D}
+import eu.proteus.job.operations.data.results.{MomentsResult, MomentsResult1D, MomentsResult2D}
 import eu.proteus.solma.moments.MomentsEstimator
+import org.apache.flink.api.common.state.{MapState, MapStateDescriptor}
 import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.co.RichCoFlatMapFunction
 import org.apache.flink.streaming.api.scala._
+import org.apache.flink.util.Collector
+
+import scala.collection.mutable
 
 object MomentsOperation {
 
   def runSimpleMomentsAnalytics(
       stream: DataStream[CoilMeasurement],
       featuresCount: Int
- ): DataStream[MomentsResult] = {
+  ): DataStream[MomentsResult] = {
 
     implicit val typeInfo = TypeInformation.of(classOf[(CoilMeasurement, Int)])
+
+    var kstream: KeyedStream[(CoilMeasurement, Int), Int] = null
 
     val momentsEstimator = MomentsEstimator()
       .setFeaturesCount(1)
       .enableAggregation(false)
       .setPartitioning((in) => {
-        in
+
+        kstream = in
           .asInstanceOf[DataStream[(CoilMeasurement)]]
           .map(
-          (coilMeasurement: CoilMeasurement) => {
-            val sensorId = coilMeasurement.slice.head
-            coilMeasurement.slice = 0 to 0
-            (coilMeasurement, coilMeasurement.coilId * featuresCount + sensorId)
+            (coilMeasurement: CoilMeasurement) => {
+              val sensorId = coilMeasurement.slice.head
+              (coilMeasurement, coilMeasurement.coilId * featuresCount + sensorId)
             }
           )
           .keyBy(x => x._2)
-          .asInstanceOf[KeyedStream[(Any, Int), Int]]
+
+        kstream.map(
+          (t) => {
+            val (coilMeasurement, pid) = t
+            val clone = coilMeasurement match {
+              case s1d: SensorMeasurement1D => s1d.copy(slice = 0 to 0)
+              case s2d: SensorMeasurement2D => s2d.copy(slice = 0 to 0)
+            }
+            (clone.asInstanceOf[CoilMeasurement], pid)
+            }
+        )
+        .keyBy(x => x._2)
+        .asInstanceOf[KeyedStream[(Any, Int), Int]]
       })
 
     val moments = momentsEstimator.transform(stream)
 
-    moments.flatMap((t, out) => {
-      val (pid: Int, metrics: MomentsEstimator.Moments) = t
-      val variance = metrics.variance(0)
-      if (!java.lang.Double.isNaN(variance)) {
-        val cid = pid % featuresCount
-        val sid = pid / featuresCount
-        out.collect(MomentsResult(cid, sid, metrics.mean(0), variance, metrics.counter(0)))
-      }
+    kstream
+      .connect(moments.keyBy(x => x._1))
+      .flatMap(new RichCoFlatMapFunction[(CoilMeasurement, Int), (Int, MomentsEstimator.Moments), MomentsResult]() {
+
+        @Transient
+        private var map: MapState[Int, mutable.Queue[(Option[Double], Option[Double])]] = _
+
+        override def open(parameters: Configuration): Unit = {
+          super.open(parameters)
+          val descriptor = new MapStateDescriptor[Int, mutable.Queue[(Option[Double], Option[Double])]](
+            "coords",
+            TypeInformation.of(classOf[Int]),
+            TypeInformation.of(classOf[mutable.Queue[(Option[Double], Option[Double])]])
+          )
+          map = getRuntimeContext.getMapState(descriptor)
+        }
+
+        override def flatMap1(value: (CoilMeasurement, Int), out: Collector[MomentsResult]): Unit = {
+          val key = value._1.coilId * featuresCount + value._1.slice.head
+          val v = value._1 match {
+            case s1d: SensorMeasurement1D => (Some(s1d.x), None)
+            case s2d: SensorMeasurement2D => (Some(s2d.x), Some(s2d.y))
+          }
+          val queue = if (map.contains(key)) {
+            map.get(key)
+          } else {
+            val q = mutable.Queue[(Option[Double], Option[Double])]()
+            map.put(key, q)
+            q
+          }
+          queue += v
+        }
+
+        override def flatMap2(in: (Int, MomentsEstimator.Moments), out: Collector[MomentsResult]): Unit = {
+          val (pid: Int, metrics: MomentsEstimator.Moments) = in
+          val cid = pid % featuresCount
+          val sid = pid / featuresCount
+          val q = map.get(pid)
+          if (q.isEmpty) {
+            throw new RuntimeException("this queue is not supposed to be empty!")
+          }
+          val (ox, oy) = q.dequeue
+          val result = oy match {
+            case Some(y) => MomentsResult2D(cid, sid, metrics.mean(0), ox.get, y, metrics.variance(0), metrics.counter(0))
+            case None => MomentsResult1D(cid, sid, metrics.mean(0), ox.get, metrics.variance(0), metrics.counter(0))
+          }
+          out.collect(result)
+        }
+
     })
+    .name("coil-xy-join")
+    .uid("coil-xy-join")
+
 
   }
 

--- a/src/main/scala/eu/proteus/job/operations/serializer/CoilMeasurementKryoSerializer.scala
+++ b/src/main/scala/eu/proteus/job/operations/serializer/CoilMeasurementKryoSerializer.scala
@@ -24,7 +24,6 @@ import org.apache.flink.ml.math.{DenseVector => FlinkDenseVector}
 
 class CoilMeasurementKryoSerializer extends Serializer[CoilMeasurement] {
 
-  private val MAGIC_NUMBER = 0x00687691 // PROTEUS EU id
 
   override def read(kryo: Kryo, input: Input, t: Class[CoilMeasurement]): CoilMeasurement = {
 
@@ -55,12 +54,12 @@ class CoilMeasurementKryoSerializer extends Serializer[CoilMeasurement] {
     output.writeInt(MAGIC_NUMBER)
     val sm = obj match {
       case s1d: SensorMeasurement1D =>
-        output.writeByte(0x00)
+        output.writeByte(COIL_MEASUREMENT_1D)
         output.writeInt(obj.coilId)
         output.writeDouble(s1d.x)
         s1d
       case s2d: SensorMeasurement2D =>
-        output.writeByte(0x01)
+        output.writeByte(COIL_MEASUREMENT_2D)
         output.writeInt(obj.coilId)
         output.writeDouble(s2d.x)
         output.writeDouble(s2d.y)

--- a/src/main/scala/eu/proteus/job/operations/serializer/package.scala
+++ b/src/main/scala/eu/proteus/job/operations/serializer/package.scala
@@ -1,0 +1,16 @@
+package eu.proteus.job.operations
+
+
+package object serializer {
+
+
+  private [serializer] val MAGIC_NUMBER = 0x00687691 // PROTEUS EU id
+
+  private [serializer] val COIL_MEASUREMENT_1D = 0x00
+  private [serializer] val COIL_MEASUREMENT_2D = 0x01
+
+  private [serializer] val MOMENTS_RESULT_1D = 0x00
+  private [serializer] val MOMENTS_RESULT_2D = 0x01
+
+
+}

--- a/src/test/scala/eu/proteus/job/kernel/KafkaIntegrationITSuite.scala
+++ b/src/test/scala/eu/proteus/job/kernel/KafkaIntegrationITSuite.scala
@@ -152,12 +152,6 @@ class KafkaIntegrationITSuite
 
 object KafkaIntegrationITSuite {
 
-  @BeforeClass
-  def prepare = KafkaTestBase.prepare()
-
-  @AfterClass
-  def shutdown = KafkaTestBase.shutDownServices()
-
   private def extractField(field: String): Field = {
     val f = classOf[KafkaTestBase].getDeclaredField(field)
     f.setAccessible(true)

--- a/src/test/scala/eu/proteus/job/operations/data/results/MomentsResultKryoSerializerUTSuite.scala
+++ b/src/test/scala/eu/proteus/job/operations/data/results/MomentsResultKryoSerializerUTSuite.scala
@@ -20,6 +20,7 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.{Input, Output}
 import eu.proteus.job.operations.serializer.MomentsResultKryoSerializer
 import org.junit.runner.RunWith
+import org.scalatest.exceptions.TestFailedException
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 import org.scalatest.junit.JUnitRunner
 
@@ -47,10 +48,18 @@ class MomentsResultKryoSerializerUTSuite
     kryo.writeObject(out, m1D)
     kryo.writeObject(out, m2D)
 
-    an [UnsupportedOperationException] should be thrownBy {
-      kryo.readObject(in, classOf[MomentsResult])
-      kryo.readObject(in, classOf[MomentsResult])
+    val m1 = kryo.readObject(in, classOf[MomentsResult])
+
+    an [TestFailedException] should be thrownBy {
+      // NaN is not equal to NaN
+      m1 shouldEqual m1D
     }
+
+    m1.variance.isNaN shouldEqual m1D.variance.isNaN
+
+    val m2 = kryo.readObject(in, classOf[MomentsResult])
+    m2 shouldEqual m2D
+
 
   }
 

--- a/src/test/scala/eu/proteus/job/operations/data/results/MomentsResultKryoSerializerUTSuite.scala
+++ b/src/test/scala/eu/proteus/job/operations/data/results/MomentsResultKryoSerializerUTSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.job.operations.data.results
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.{Input, Output}
+import eu.proteus.job.operations.serializer.MomentsResultKryoSerializer
+import org.junit.runner.RunWith
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.junit.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class MomentsResultKryoSerializerUTSuite
+  extends WordSpecLike
+  with Matchers
+  with BeforeAndAfterAll {
+
+  "test kryo serialization" in {
+
+    val kryo = new Kryo()
+    val ser = new MomentsResultKryoSerializer
+    kryo.register(classOf[MomentsResult], ser)
+    kryo.register(classOf[MomentsResult1D], ser)
+    kryo.register(classOf[MomentsResult2D], ser)
+
+    val m1D = MomentsResult1D(1, 1, 13.5, 1.0, Double.NaN, 1.0)
+    val m2D = MomentsResult2D(4, 2, 53.5, 0.546, 2.05, 0.45767, 12.0)
+
+    val out = new Output(1024)
+    val in = new Input(out.getBuffer)
+
+    kryo.writeObject(out, m1D)
+    kryo.writeObject(out, m2D)
+
+    an [UnsupportedOperationException] should be thrownBy {
+      kryo.readObject(in, classOf[MomentsResult])
+      kryo.readObject(in, classOf[MomentsResult])
+    }
+
+  }
+
+}

--- a/src/test/scala/eu/proteus/job/operations/moments/MomentsITSuite.scala
+++ b/src/test/scala/eu/proteus/job/operations/moments/MomentsITSuite.scala
@@ -20,7 +20,6 @@ import java.lang.reflect.Field
 import java.util.{Properties, UUID}
 
 import eu.proteus.job.operations.data.model.{CoilMeasurement, SensorMeasurement1D, SensorMeasurement2D}
-import eu.proteus.job.operations.data.results.MomentsResult
 import eu.proteus.job.operations.serializer.CoilMeasurementKryoSerializer
 import grizzled.slf4j.Logger
 import kafka.common.NotLeaderForPartitionException
@@ -38,7 +37,7 @@ import org.apache.flink.streaming.connectors.kafka.testutils.JobManagerCommunica
 import org.apache.flink.streaming.util.serialization.{KeyedSerializationSchemaWrapper, TypeInformationSerializationSchema}
 import org.apache.flink.test.util.SuccessException
 import org.apache.flink.testutils.junit.RetryOnException
-import org.junit.{AfterClass, BeforeClass, Test}
+import org.junit.Test
 import org.scalatest.junit.JUnitSuiteLike
 
 import scala.concurrent.duration.FiniteDuration
@@ -122,11 +121,10 @@ class MomentsITSuite
 
     val result = MomentsOperation.runSimpleMomentsAnalytics(consuming, 53)
 
-    result.addSink(new SinkFunction[MomentsResult]() {
+    result.addSink(new SinkFunction[String]() {
       var e = 0
-      override def invoke(in: MomentsResult): Unit = {
+      override def invoke(in: String): Unit = {
         e += 1
-        val v = in.toJson
         if (e == s.length) {
           throw new SuccessException
         }

--- a/src/test/scala/eu/proteus/job/operations/moments/MomentsITSuite.scala
+++ b/src/test/scala/eu/proteus/job/operations/moments/MomentsITSuite.scala
@@ -125,7 +125,7 @@ class MomentsITSuite
       var e = 0
       override def invoke(in: String): Unit = {
         e += 1
-        if (e == s.length) {
+        if (e == 5) {
           throw new SuccessException
         }
       }

--- a/src/test/scala/eu/proteus/job/operations/moments/MomentsITSuite.scala
+++ b/src/test/scala/eu/proteus/job/operations/moments/MomentsITSuite.scala
@@ -127,7 +127,7 @@ class MomentsITSuite
       override def invoke(in: MomentsResult): Unit = {
         e += 1
         val v = in.toJson
-        if (e == 5) {
+        if (e == s.length) {
           throw new SuccessException
         }
       }
@@ -163,12 +163,6 @@ class MomentsITSuite
 }
 
 object MomentsITSuite {
-
-  @BeforeClass
-  def prepare = KafkaTestBase.prepare()
-
-  @AfterClass
-  def shutdown = KafkaTestBase.shutDownServices()
 
   private def extractField(field: String): Field = {
     val f = classOf[KafkaTestBase].getDeclaredField(field)

--- a/src/test/scala/eu/proteus/job/operations/moments/MomentsITSuite.scala
+++ b/src/test/scala/eu/proteus/job/operations/moments/MomentsITSuite.scala
@@ -53,7 +53,6 @@ class MomentsITSuite
 
   private [moments] val LOG = Logger(getClass)
 
-
   @Test
   def runSimpleMomentsIntegrationWithKafka(): Unit = {
 
@@ -84,14 +83,14 @@ class MomentsITSuite
 
     val s = Seq(
         SensorMeasurement1D(0, 12.0, 0 to 0, FlinkDenseVector(1.0)),
-        SensorMeasurement2D(1, 12.0, 1.0, 1 to 1, FlinkDenseVector(1.2)),
-        SensorMeasurement1D(4, 12.0, 0 to 0, FlinkDenseVector(1.5)),
-        SensorMeasurement2D(1, 12.0, 1.6, 1 to 1, FlinkDenseVector(1.1)),
-        SensorMeasurement1D(0, 12.0, 0 to 0, FlinkDenseVector(1.0)),
-        SensorMeasurement2D(2, 12.0, 2.4, 3 to 3, FlinkDenseVector(1.2)),
-        SensorMeasurement1D(2, 12.0, 3 to 3, FlinkDenseVector(1.0)),
-        SensorMeasurement1D(4, 12.0, 0 to 0, FlinkDenseVector(1.4)),
-        SensorMeasurement1D(2, 12.0, 3 to 3, FlinkDenseVector(1.0))
+        SensorMeasurement2D(1, 13.0, 1.0, 1 to 1, FlinkDenseVector(1.2)),
+        SensorMeasurement1D(4, 14.0, 0 to 0, FlinkDenseVector(1.5)),
+        SensorMeasurement2D(1, 17.0, 1.6, 1 to 1, FlinkDenseVector(1.1)),
+        SensorMeasurement1D(0, 18.0, 0 to 0, FlinkDenseVector(1.0)),
+        SensorMeasurement2D(2, 19.0, 2.4, 3 to 3, FlinkDenseVector(1.2)),
+        SensorMeasurement1D(2, 20.0, 3 to 3, FlinkDenseVector(1.0)),
+        SensorMeasurement1D(4, 21.0, 0 to 0, FlinkDenseVector(1.4)),
+        SensorMeasurement1D(2, 22.0, 3 to 3, FlinkDenseVector(1.0))
     )
     val stream = env.addSource((ctx: SourceContext[CoilMeasurement]) => {
       for (m <- s) {


### PR DESCRIPTION
This PR changes the simple moments output format to include x[,y] coil coords in the outputted json.