### PR TITLE
Add Untagged Objects Serialization Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ mvn clean install
 mvn clean package -DskipTest
 ```
 
-This will produce a shaded jar called ```proteus-job_2.10-0.1-SNAPSHOT.jar``` in ```target/''' dir. This jar can be submitted to a proteus-engine cluster.
+This will produce a shaded jar called ```proteus-job_2.10-0.1-SNAPSHOT.jar``` in ```target/``` dir. This jar can be submitted to a proteus-engine cluster.
 
 ### How to run it
 
 ```
-./flink run <JOBS_PARAMS> proteus-job_2.10-0.1-SNAPSHOT.jar --boostrap-server <KAFKA_BOOTSTRAP_SERVER> --flink-checkpoints-dir <HDFS_PATH>
+./flink run <JOB_PARAMS> proteus-job_2.10-0.1-SNAPSHOT.jar --boostrap-server <KAFKA_BOOTSTRAP_SERVER> --flink-checkpoints-dir <HDFS_PATH>
 ```
+
+You find a complete list of JOB_PARAMS in [Flink documentation](https://ci.apache.org/projects/flink/flink-docs-release-1.3/setup/cli.html).

--- a/pom.xml
+++ b/pom.xml
@@ -422,6 +422,7 @@
 					<version>${log4j.version}</version>
 					<scope>provided</scope>
 				</dependency>
+
 			</dependencies>
 
 			<properties>
@@ -517,6 +518,8 @@
 									<exclude>com.data-artisans:frocksdbjni</exclude>
 									<exclude>io.netty:netty-all</exclude>
 									<exclude>io.netty:netty</exclude>
+									<exclude>com.esotericsoftware.kryo:kryo</exclude>
+									<exclude>com.esotericsoftware.minlog:minlog</exclude>
 									<exclude>commons-fileupload:commons-fileupload</exclude>
 									<exclude>org.apache.avro:avro</exclude>
 									<exclude>commons-collections:commons-collections</exclude>
@@ -524,8 +527,6 @@
 									<exclude>org.xerial.snappy:snappy-java</exclude>
 									<exclude>org.apache.commons:commons-compress</exclude>
 									<exclude>org.tukaani:xz</exclude>
-									<exclude>com.esotericsoftware.kryo:kryo</exclude>
-									<exclude>com.esotericsoftware.minlog:minlog</exclude>
 									<exclude>org.objenesis:objenesis</exclude>
 									<exclude>com.twitter:chill_*</exclude>
 									<exclude>com.twitter:chill-java</exclude>

--- a/src/main/scala/eu/proteus/job/operations/data/serializer/CoilMeasurementKryoSerializer.scala
+++ b/src/main/scala/eu/proteus/job/operations/data/serializer/CoilMeasurementKryoSerializer.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package eu.proteus.job.operations.serializer
+package eu.proteus.job.operations.data.serializer
 
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, Serializer}
@@ -22,8 +22,9 @@ import eu.proteus.job.operations.data.model.{CoilMeasurement, SensorMeasurement1
 import org.apache.flink.ml.math.{DenseVector => FlinkDenseVector}
 
 
-class CoilMeasurementKryoSerializer extends Serializer[CoilMeasurement] {
-
+class CoilMeasurementKryoSerializer
+  extends Serializer[CoilMeasurement]
+  with Serializable {
 
   override def read(kryo: Kryo, input: Input, t: Class[CoilMeasurement]): CoilMeasurement = {
 

--- a/src/main/scala/eu/proteus/job/operations/data/serializer/MomentsResultKryoSerializer.scala
+++ b/src/main/scala/eu/proteus/job/operations/data/serializer/MomentsResultKryoSerializer.scala
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package eu.proteus.job.operations.serializer
+package eu.proteus.job.operations.data.serializer
 
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, Serializer}
 import eu.proteus.job.operations.data.results.{MomentsResult, MomentsResult1D, MomentsResult2D}
 
 
-class MomentsResultKryoSerializer extends Serializer[MomentsResult] {
+class MomentsResultKryoSerializer
+  extends Serializer[MomentsResult]
+  with Serializable {
 
   override def read(kryo: Kryo, input: Input, t: Class[MomentsResult]): MomentsResult = {
 

--- a/src/main/scala/eu/proteus/job/operations/data/serializer/package.scala
+++ b/src/main/scala/eu/proteus/job/operations/data/serializer/package.scala
@@ -1,8 +1,6 @@
-package eu.proteus.job.operations
-
+package eu.proteus.job.operations.data
 
 package object serializer {
-
 
   private [serializer] val MAGIC_NUMBER = 0x00687691 // PROTEUS EU id
 

--- a/src/main/scala/eu/proteus/job/operations/data/serializer/schema/UntaggedObjectSerializationSchema.scala
+++ b/src/main/scala/eu/proteus/job/operations/data/serializer/schema/UntaggedObjectSerializationSchema.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2017 The Proteus Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.proteus.job.operations.data.serializer.schema
+
+import java.io.{EOFException, IOException}
+
+import com.esotericsoftware.kryo.KryoException
+import com.esotericsoftware.kryo.io.Output
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
+import org.apache.flink.api.java.typeutils.runtime.{DataInputViewStream, DataOutputViewStream, NoFetchingInput}
+import org.apache.flink.runtime.util.{DataInputDeserializer, DataOutputSerializer}
+import org.apache.flink.streaming.util.serialization.{DeserializationSchema, SerializationSchema}
+
+import scala.reflect.ClassTag
+
+class UntaggedObjectSerializationSchema[T: TypeInformation : ClassTag](cfg: ExecutionConfig)
+    extends DeserializationSchema[T]
+    with SerializationSchema[T] {
+
+  @transient
+  private [schema] var dis: DataInputDeserializer = _
+
+  @transient
+  private [schema] var dos: DataOutputSerializer = _
+
+  @transient
+  private [schema] var noFetchingInput: NoFetchingInput = _
+
+  @transient
+  private [schema] var output: Output = _
+
+  private [schema] val typeInfo = implicitly[TypeInformation[T]]
+
+  private [schema] val serializer = typeInfo.createSerializer(cfg)
+
+  override def isEndOfStream(nextElement: T): Boolean = false
+
+  override def deserialize(message: Array[Byte]): T = {
+    if (dis != null) {
+      dis.setBuffer(message, 0, message.length)
+    } else {
+      dis = new DataInputDeserializer(message, 0, message.length)
+      noFetchingInput = new NoFetchingInput(new DataInputViewStream(dis))
+    }
+    try {
+      serializer match {
+        case k: KryoSerializer[T] => {
+          val kryo = k.getKryo
+          try {
+            kryo.readObject(noFetchingInput, typeInfo.getTypeClass)
+          } catch {
+            case ke: KryoException => {
+              ke.getCause match {
+                case cause: EOFException => throw cause
+                case _ => throw ke
+              }
+            }
+          }
+        }
+        case _ => {
+          throw new UnsupportedOperationException
+        }
+      }
+    } catch {
+      case e: IOException => {
+        throw new RuntimeException("Unable to deserialize message", e)
+      }
+    }
+  }
+
+  override def serialize(element: T): Array[Byte] = {
+    if (dos == null) {
+      dos = new DataOutputSerializer(16)
+      output = new Output(new DataOutputViewStream(dos))
+    }
+
+    try {
+      serializer match {
+        case k: KryoSerializer[T] => {
+          val kryo = k.getKryo
+          // Sanity check: Make sure that the output is cleared/has been flushed by the last call
+          // otherwise data might be written multiple times in case of a previous EOFException
+          if (output.position != 0) {
+            throw new IllegalStateException("The Kryo Output still contains data from a previous " +
+              "serialize call. It has to be flushed or cleared at the end of the serialize call.")
+          }
+          try {
+            kryo.writeObject(output, element)
+            output.flush()
+          } catch {
+            case ke: KryoException => {
+              ke.getCause match {
+                case cause: EOFException => throw cause
+                case _ => throw ke
+              }
+            }
+          }
+        }
+        case _ => {
+          throw new UnsupportedOperationException
+        }
+      }
+    } catch {
+      case e: IOException => {
+        throw new RuntimeException("Unable to serialize record", e)
+      }
+    }
+    var ret = dos.getByteArray
+    if (ret.length != dos.length) {
+      val n = new Array[Byte](dos.length)
+      System.arraycopy(ret, 0, n, 0, dos.length)
+      ret = n
+    }
+    dos.clear()
+    ret
+  }
+
+  override def getProducedType: TypeInformation[T] = typeInfo
+}

--- a/src/test/scala/eu/proteus/job/operations/data/model/CoilMeasurementKryoSerializerUTSuite.scala
+++ b/src/test/scala/eu/proteus/job/operations/data/model/CoilMeasurementKryoSerializerUTSuite.scala
@@ -18,7 +18,7 @@ package eu.proteus.job.operations.data.model
 
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.{Input, Output}
-import eu.proteus.job.operations.serializer.CoilMeasurementKryoSerializer
+import eu.proteus.job.operations.data.serializer.CoilMeasurementKryoSerializer
 import org.apache.flink.ml.math.{DenseVector => FlinkDenseVector}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/src/test/scala/eu/proteus/job/operations/data/results/MomentsResultKryoSerializerUTSuite.scala
+++ b/src/test/scala/eu/proteus/job/operations/data/results/MomentsResultKryoSerializerUTSuite.scala
@@ -18,7 +18,7 @@ package eu.proteus.job.operations.data.results
 
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.{Input, Output}
-import eu.proteus.job.operations.serializer.MomentsResultKryoSerializer
+import eu.proteus.job.operations.data.serializer.MomentsResultKryoSerializer
 import org.junit.runner.RunWith
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}

--- a/src/test/scala/eu/proteus/job/operations/moments/MomentsITSuite.scala
+++ b/src/test/scala/eu/proteus/job/operations/moments/MomentsITSuite.scala
@@ -20,7 +20,8 @@ import java.lang.reflect.Field
 import java.util.{Properties, UUID}
 
 import eu.proteus.job.operations.data.model.{CoilMeasurement, SensorMeasurement1D, SensorMeasurement2D}
-import eu.proteus.job.operations.serializer.CoilMeasurementKryoSerializer
+import eu.proteus.job.operations.data.serializer.CoilMeasurementKryoSerializer
+import eu.proteus.job.operations.data.serializer.schema.UntaggedObjectSerializationSchema
 import grizzled.slf4j.Logger
 import kafka.common.NotLeaderForPartitionException
 import org.apache.flink.api.common.restartstrategy.RestartStrategies
@@ -75,8 +76,8 @@ class MomentsITSuite
     env.getConfig.registerTypeWithKryoSerializer(classOf[SensorMeasurement2D], classOf[CoilMeasurementKryoSerializer])
     env.getConfig.registerTypeWithKryoSerializer(classOf[SensorMeasurement1D], classOf[CoilMeasurementKryoSerializer])
 
-    val typeInfo = TypeInformation.of(classOf[CoilMeasurement])
-    val schema = new TypeInformationSerializationSchema[CoilMeasurement](typeInfo, env.getConfig)
+    implicit val typeInfo = TypeInformation.of(classOf[CoilMeasurement])
+    val schema = new UntaggedObjectSerializationSchema[CoilMeasurement](env.getConfig)
 
     // ----------- add producer dataflow ----------
 


### PR DESCRIPTION
This PR fixes a subtle bug that was caused by underlying Flink API, which only used kryo#readClassObject while reading from kafka. This PR introduces a new Deserialization schema that uses kryo#readObject.