### PR TITLE
Enable checkpointing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You find a complete list of JOB_PARAMS in [Flink documentation](https://ci.apach
 1. **state-backend**	Flink State Backend [memory|rocksdb]
 2. **state-backend-mbsize**	Flink Memory State Backend size in MB (default: 20)
 3. **flink-checkpoints-dir** A valid directory in which Flink will store Rocksdb checkpoints, e.g., hdfs://namenode:9000/flink-checkpoints/
-
+4. **flink-checkpoints-interval**	Flink Checkpoints Interval in mins (default: 10)
 ### How to run it within your IDE
 
 In order to local test your job within your IDe, you need to select ```ide-testing``` maven profile.


### PR DESCRIPTION
This PR aims to address #13. It enables checkpointing in at-least-once fashion every N minutes. The checkpoints interval is configurable. Default value is 10 minutes.